### PR TITLE
Added MathJax support

### DIFF
--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -30,6 +30,7 @@
         <dependency>com.atlassian.bitbucket.server.bitbucket-web:global</dependency>
         <dependency>${project.groupId}.${project.artifactId}:asciidoctor</dependency>
         <dependency>${project.groupId}.${project.artifactId}:highlight</dependency>
+        <dependency>${project.groupId}.${project.artifactId}:mathjax</dependency>
     </client-resource>
 
     <client-resource key="asciidoctor" name="Asciidoctor JS Library">
@@ -41,5 +42,9 @@
         <resource type="download" name="highlight.js" location="/static/lib/highlight/highlight.js" />
         <directory location="/static/lib/highlight" />
     </client-resource>
-
+    
+    <client-resource key="mathjax" name="MathJax JS Library">
+        <resource type="download" name="mathjax-loader.js" location="/static/lib/mathjax/mathjax-loader.js" />
+        <directory location="/static/lib/mathjax" />
+    </client-resource>
 </atlassian-plugin>

--- a/src/main/resources/static/lib/mathjax/mathjax-loader.js
+++ b/src/main/resources/static/lib/mathjax/mathjax-loader.js
@@ -1,0 +1,10 @@
+(function () {
+  /**
+   * Loads MathJax from the official CDN
+   */
+    var script=document.createElement('script');
+    script.type = "text/javascript";
+    script.src = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML";
+    document.getElementsByTagName("head")[0].appendChild(script);
+
+})();


### PR DESCRIPTION
Thanks for creating this plugin. I have just added a loader of the standard MathJax library so that equations in the asciidoc get rendered.
